### PR TITLE
Delete events cache after login or register

### DIFF
--- a/EsmorgaiOS/App/Data/DataSource/Events/LocalEventsDataSource.swift
+++ b/EsmorgaiOS/App/Data/DataSource/Events/LocalEventsDataSource.swift
@@ -11,6 +11,7 @@ import CoreData
 protocol LocalEventsDataSourceProtocol {
     func getEvents() async -> [EventModels.Event]
     func saveEvents(_ events: [EventModels.Event]) async throws -> ()
+    func clearAll()
 }
 
 class LocalEventsDataSource: LocalEventsDataSourceProtocol {

--- a/EsmorgaiOS/App/Screens/EventList/EventListView.swift
+++ b/EsmorgaiOS/App/Screens/EventList/EventListView.swift
@@ -42,7 +42,9 @@ struct EventListView: View {
                                          subtitle: LocalizationKeys.DefaultError.body.localize())
                                 CustomButton(title: LocalizationKeys.Buttons.retry.localize(),
                                              buttonStyle: .primary) {
-                                    viewModel.getEventList(forceRefresh: true)
+                                    Task {
+                                        await viewModel.getEventList(forceRefresh: true)
+                                    }
                                 }
                                              .frame(maxWidth: .infinity, alignment: .center)
                             }.padding(16)
@@ -68,7 +70,9 @@ struct EventListView: View {
                     }.frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .onAppear {
-                    viewModel.getEventList(forceRefresh: false)
+                    Task {
+                        await viewModel.getEventList(forceRefresh: false)
+                    }
                 }
             }
             .navigationBarBackButtonHidden(true)

--- a/EsmorgaiOS/App/Screens/EventList/EventListView.swift
+++ b/EsmorgaiOS/App/Screens/EventList/EventListView.swift
@@ -67,7 +67,7 @@ struct EventListView: View {
                         }
                     }.frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .onFirstAppear {
+                .onAppear {
                     viewModel.getEventList(forceRefresh: false)
                 }
             }

--- a/EsmorgaiOS/App/Screens/EventList/EventListViewModel.swift
+++ b/EsmorgaiOS/App/Screens/EventList/EventListViewModel.swift
@@ -30,36 +30,30 @@ class EventListViewModel: BaseViewModel<EventListViewStates> {
         coordinator?.push(destination: .eventDetails(event))
     }
 
-    func getEventList(forceRefresh: Bool) {
+    @MainActor
+    func getEventList(forceRefresh: Bool) async {
 
         if self.state == .ready || forceRefresh {
             changeState(.loading)
         }
 
-        Task { [weak self] in
-            guard let self else { return }
+        let result = await getEventListUseCase.execute(input: forceRefresh)
 
-            let result = await getEventListUseCase.execute(input: forceRefresh)
-
-            await MainActor.run {
-
-                switch result {
-                case .success(let events):
-                    self.events = events.data
-                    if events.data.isEmpty {
-                        self.changeState(.empty)
-                    } else {
-                        self.changeState(.loaded)
-                    }
-
-                    if events.error {
-                        self.snackBar = .init(message: LocalizationKeys.Snackbar.noInternet.localize(),
-                                              isShown: true)
-                    }
-                case .failure:
-                    self.changeState(.error)
-                }
+        switch result {
+        case .success(let events):
+            self.events = events.data
+            if events.data.isEmpty {
+                self.changeState(.empty)
+            } else {
+                self.changeState(.loaded)
             }
+
+            if events.error {
+                self.snackBar = .init(message: LocalizationKeys.Snackbar.noInternet.localize(),
+                                      isShown: true)
+            }
+        case .failure:
+            self.changeState(.error)
         }
     }
 }

--- a/EsmorgaiOS/App/Screens/EventList/EventListViewModel.swift
+++ b/EsmorgaiOS/App/Screens/EventList/EventListViewModel.swift
@@ -32,7 +32,9 @@ class EventListViewModel: BaseViewModel<EventListViewStates> {
 
     func getEventList(forceRefresh: Bool) {
 
-        changeState(.loading)
+        if self.state == .ready || forceRefresh {
+            changeState(.loading)
+        }
 
         Task { [weak self] in
             guard let self else { return }

--- a/EsmorgaiOS/App/Screens/MyEvents/MyEventsView.swift
+++ b/EsmorgaiOS/App/Screens/MyEvents/MyEventsView.swift
@@ -42,12 +42,13 @@ struct MyEventsView: View {
                                     buttonText: LocalizationKeys.Buttons.login.localize(),
                                     action: { viewModel.loginButtonTapped() })
                 }
-            }.frame(maxWidth: .infinity, alignment: .leading)
-                .onFirstAppear {
-                    Task {
-                        await viewModel.getEventList(forceRefresh: false)
-                    }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onAppear {
+                Task {
+                    await viewModel.getEventList(forceRefresh: false)
                 }
+            }
         }.navigationBarBackButtonHidden(true)
     }
 

--- a/EsmorgaiOS/App/Screens/MyEvents/MyEventsViewModel.swift
+++ b/EsmorgaiOS/App/Screens/MyEvents/MyEventsViewModel.swift
@@ -38,7 +38,11 @@ class MyEventsViewModel: BaseViewModel<MyEventsViewStates> {
 
     @MainActor
     func getEventList(forceRefresh: Bool) async {
-        changeState(.loading)
+
+        if self.state == .ready || forceRefresh {
+            changeState(.loading)
+
+        }
 
         let isUserLogged = await getLocalUserUseCase.execute()
 

--- a/EsmorgaiOSTests/App/Data/DataSource/Events/Mock/MockLocalEventsDataSource.swift
+++ b/EsmorgaiOSTests/App/Data/DataSource/Events/Mock/MockLocalEventsDataSource.swift
@@ -12,6 +12,7 @@ final class MockLocalEventsDataSource: LocalEventsDataSourceProtocol {
 
     var mockEvents: [EventModels.Event] = []
     var savedEvents: [EventModels.Event]?
+    var clearAllCalled: Bool = false
 
     func getEvents() async -> [EventModels.Event] {
         return mockEvents
@@ -20,5 +21,10 @@ final class MockLocalEventsDataSource: LocalEventsDataSourceProtocol {
     func saveEvents(_ events: [EventModels.Event]) async throws {
         savedEvents = events
         return
+    }
+
+    func clearAll() {
+        savedEvents = nil
+        clearAllCalled = true
     }
 }

--- a/EsmorgaiOSTests/App/Data/Repository/User/UserRepositoryTests.swift
+++ b/EsmorgaiOSTests/App/Data/Repository/User/UserRepositoryTests.swift
@@ -16,17 +16,20 @@ final class UserRepositoryTests {
     private var mockLoginUserDataSource: MockLoginUserDataSource!
     private var mockRegisterUserDataSource: MockRegisterUserDataSource!
     private var mockLocalUserDataSource: MockLocalUserDataSource!
+    private var mockLocalEventsDataSource: MockLocalEventsDataSource!
     private var sessionKeychain: CodableKeychain<AccountSession>!
 
     init() {
         mockLoginUserDataSource = MockLoginUserDataSource()
         mockRegisterUserDataSource = MockRegisterUserDataSource()
         mockLocalUserDataSource = MockLocalUserDataSource()
+        mockLocalEventsDataSource = MockLocalEventsDataSource()
         sessionKeychain = AccountSession.buildCodableKeychain()
         try? sessionKeychain.delete()
         sut = UserRepository(localUserDataSource: mockLocalUserDataSource,
                              loginUserDataSource: mockLoginUserDataSource,
                              registerUserDataSource: mockRegisterUserDataSource,
+                             localEventsDataSource: mockLocalEventsDataSource,
                              sessionKeychain: sessionKeychain)
     }
 
@@ -36,6 +39,7 @@ final class UserRepositoryTests {
         mockLoginUserDataSource = nil
         mockRegisterUserDataSource = nil
         mockLocalUserDataSource = nil
+        mockLocalEventsDataSource = nil
         sut = nil
     }
 
@@ -52,6 +56,7 @@ final class UserRepositoryTests {
         #expect(result?.lastName == remoteUser.profile.lastName)
         #expect(self.mockLocalUserDataSource.savedUser == result)
         #expect(self.sessionKeychain.isLogged)
+        #expect(self.mockLocalEventsDataSource.clearAllCalled)
     }
 
     @Test
@@ -79,6 +84,7 @@ final class UserRepositoryTests {
         #expect(result?.lastName == remoteUser.profile.lastName)
         #expect(self.mockLocalUserDataSource.savedUser == result)
         #expect(self.sessionKeychain.isLogged)
+        #expect(self.mockLocalEventsDataSource.clearAllCalled)
     }
 
     @Test

--- a/EsmorgaiOSTests/App/Screens/EventList/EventListViewModelTests.swift
+++ b/EsmorgaiOSTests/App/Screens/EventList/EventListViewModelTests.swift
@@ -5,31 +5,32 @@
 //  Created by Vidal Pérez, Omar on 31/7/24.
 //
 
-import Nimble
-import XCTest
+import Foundation
+import Testing
 @testable import EsmorgaiOS
 
-final class EventListViewModelTests: XCTestCase {
+@Suite(.serialized)
+final class EventListViewModelTests {
 
     private var sut: EventListViewModel!
     private var mockGetEventListUseCase: MockGetEventListUseCase!
     private var spyCoordinator: SpyCoordinator!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    init() {
         mockGetEventListUseCase = MockGetEventListUseCase()
         spyCoordinator = SpyCoordinator()
         sut = EventListViewModel(coordinator: spyCoordinator,
                                  getEventListUseCase: mockGetEventListUseCase)
     }
 
-    override func tearDownWithError() throws {
+    deinit {
         mockGetEventListUseCase = nil
         spyCoordinator = nil
         sut = nil
-        try super.tearDownWithError()
     }
 
+    @MainActor
+    @Test
     func test_given_get_event_list_when_success_then_events_are_correct() async {
 
         let events = [EventBuilder().with(eventId: "1").build(),
@@ -37,13 +38,17 @@ final class EventListViewModelTests: XCTestCase {
 
         mockGetEventListUseCase.mockResponse = (events, false)
 
-        sut.getEventList(forceRefresh: false)
+        await TestHelper.fullfillTask {
+            await self.sut.getEventList(forceRefresh: false)
+        }
 
-        await expect(self.sut.events).toEventually(equal(events))
-        await expect(self.sut.state).toEventually(equal(.loaded))
-        await expect(self.sut.snackBar.isShown).toEventually(beFalse())
+        #expect(self.sut.events == events)
+        #expect(self.sut.state == .loaded)
+        #expect(!self.sut.snackBar.isShown)
     }
 
+    @MainActor
+    @Test
     func test_given_get_event_list_when_success_from_cache_then_events_are_correct_and_snackbar_is_shown() async {
 
         let events = [EventBuilder().with(eventId: "1").build(),
@@ -51,29 +56,36 @@ final class EventListViewModelTests: XCTestCase {
 
         mockGetEventListUseCase.mockResponse = (events, true)
 
-        sut.getEventList(forceRefresh: false)
+        await TestHelper.fullfillTask {
+            await self.sut.getEventList(forceRefresh: false)
+        }
 
-        await expect(self.sut.events).toEventually(equal(events))
-        await expect(self.sut.state).toEventually(equal(.loaded))
-        await expect(self.sut.snackBar.isShown).toEventually(beTrue())
+        #expect(self.sut.events == events)
+        #expect(self.sut.state == .loaded)
+        #expect(self.sut.snackBar.isShown)
     }
 
+    @MainActor
+    @Test
     func test_given_get_event_list_when_failuer_then_error_is_shown() async {
 
-        sut.getEventList(forceRefresh: false)
+        await TestHelper.fullfillTask {
+            await self.sut.getEventList(forceRefresh: false)
+        }
 
-        await expect(self.sut.events).toEventually(beEmpty())
-        await expect(self.sut.state).toEventually(equal(.error))
-        await expect(self.sut.snackBar.isShown).toEventually(beFalse())
+        #expect(self.sut.events.isEmpty)
+        #expect(self.sut.state == .error)
+        #expect(!self.sut.snackBar.isShown)
     }
 
+    @Test
     func test_given_event_tapped_then_navigate_to_details_is_called() {
 
         let event = EventBuilder().with(eventId: "1").build()
 
         sut.eventTapped(event)
 
-        expect(self.spyCoordinator.pushCalled).toEventually(beTrue())
-        expect(self.spyCoordinator.destination).toEventually(equal(.eventDetails(event)))
+        #expect(self.spyCoordinator.pushCalled)
+        #expect(self.spyCoordinator.destination == .eventDetails(event))
     }
 }


### PR DESCRIPTION
Delete events cache after login or register
In EventList and MyEvents only show loader when request events first time or refresh was forced