### PR TITLE
MOB-68 Leave Event

### DIFF
--- a/EsmorgaiOS.xcodeproj/project.pbxproj
+++ b/EsmorgaiOS.xcodeproj/project.pbxproj
@@ -186,6 +186,9 @@
 		EFF8B8212CBEB97B007470A9 /* JoinEventUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8B8202CBEB977007470A9 /* JoinEventUseCaseTests.swift */; };
 		EFF8B8242CBEC2B7007470A9 /* MockJoinEventUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8B8232CBEC2AD007470A9 /* MockJoinEventUseCase.swift */; };
 		EFF8B8262CBFC01B007470A9 /* URLRequest+curl.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8B8252CBFC017007470A9 /* URLRequest+curl.swift */; };
+		EFF8B8282CBFC982007470A9 /* LeaveEventUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8B8272CBFC97B007470A9 /* LeaveEventUseCase.swift */; };
+		EFF8B82A2CBFDCF4007470A9 /* MockLeaveEventUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8B8292CBFDCED007470A9 /* MockLeaveEventUseCase.swift */; };
+		EFF8B82C2CBFDD1C007470A9 /* LeaveEventUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8B82B2CBFDD18007470A9 /* LeaveEventUseCaseTests.swift */; };
 		EFF9C8722C9991DA00DE50BC /* AccountTokensRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF9C8712C9991D200DE50BC /* AccountTokensRefresher.swift */; };
 		EFF9C8752C99921100DE50BC /* TokensRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF9C8742C99920F00DE50BC /* TokensRefresher.swift */; };
 		EFF9C8782C9992EF00DE50BC /* URLRequest+BearerToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF9C8772C9992E600DE50BC /* URLRequest+BearerToken.swift */; };
@@ -398,6 +401,9 @@
 		EFF8B8202CBEB977007470A9 /* JoinEventUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinEventUseCaseTests.swift; sourceTree = "<group>"; };
 		EFF8B8232CBEC2AD007470A9 /* MockJoinEventUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJoinEventUseCase.swift; sourceTree = "<group>"; };
 		EFF8B8252CBFC017007470A9 /* URLRequest+curl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+curl.swift"; sourceTree = "<group>"; };
+		EFF8B8272CBFC97B007470A9 /* LeaveEventUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaveEventUseCase.swift; sourceTree = "<group>"; };
+		EFF8B8292CBFDCED007470A9 /* MockLeaveEventUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLeaveEventUseCase.swift; sourceTree = "<group>"; };
+		EFF8B82B2CBFDD18007470A9 /* LeaveEventUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaveEventUseCaseTests.swift; sourceTree = "<group>"; };
 		EFF9C8712C9991D200DE50BC /* AccountTokensRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTokensRefresher.swift; sourceTree = "<group>"; };
 		EFF9C8742C99920F00DE50BC /* TokensRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensRefresher.swift; sourceTree = "<group>"; };
 		EFF9C8772C9992E600DE50BC /* URLRequest+BearerToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+BearerToken.swift"; sourceTree = "<group>"; };
@@ -840,6 +846,7 @@
 		EF65D16E2CB91F62005078D9 /* Event */ = {
 			isa = PBXGroup;
 			children = (
+				EFF8B8272CBFC97B007470A9 /* LeaveEventUseCase.swift */,
 				EFD7EF092C3D44A300C8CE70 /* GetEventListUseCase.swift */,
 				EF65D16C2CB91F56005078D9 /* JoinEventUseCase.swift */,
 			);
@@ -1299,6 +1306,7 @@
 				EFF8B8222CBEC2A5007470A9 /* Mocks */,
 				EFF8B8202CBEB977007470A9 /* JoinEventUseCaseTests.swift */,
 				EF31585A2C59384800DE157A /* GetEventListUseCaseTests.swift */,
+				EFF8B82B2CBFDD18007470A9 /* LeaveEventUseCaseTests.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -1431,6 +1439,7 @@
 		EFF8B8222CBEC2A5007470A9 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				EFF8B8292CBFDCED007470A9 /* MockLeaveEventUseCase.swift */,
 				EFF8B8232CBEC2AD007470A9 /* MockJoinEventUseCase.swift */,
 				EF3158812C5A80AC00DE157A /* MockGetEventListUseCase.swift */,
 			);
@@ -1741,6 +1750,7 @@
 				EF0811D32C9325EF00DE4887 /* DashboardBuilder.swift in Sources */,
 				EFE34D962C74A59800724DDC /* LoginUserDataSource.swift in Sources */,
 				EF503C0A2C98753F00EE9128 /* AccountSession.swift in Sources */,
+				EFF8B8282CBFC982007470A9 /* LeaveEventUseCase.swift in Sources */,
 				EF4213D62C413FC800686033 /* SnackbarView.swift in Sources */,
 				EF2983E72C6B729A00C2393E /* WelcomeScreenBuilder.swift in Sources */,
 				EFE0A9792C3D925600E28953 /* TextStyles.swift in Sources */,
@@ -1833,6 +1843,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EFE34DCA2C7CC07700724DDC /* LoginViewModelTests.swift in Sources */,
+				EFF8B82C2CBFDD1C007470A9 /* LeaveEventUseCaseTests.swift in Sources */,
 				EF3158672C5A281D00DE157A /* MockEventsRepository.swift in Sources */,
 				EFD6100C2CA2C40800E3DB1E /* EventBuilder.swift in Sources */,
 				EF2128392C85D5C200D00887 /* MockRegisterUserDataSource.swift in Sources */,
@@ -1856,6 +1867,7 @@
 				EFF8B8242CBEC2B7007470A9 /* MockJoinEventUseCase.swift in Sources */,
 				EF2983FA2C6B987A00C2393E /* EventDetailsViewModelTests.swift in Sources */,
 				EF21283D2C85D98800D00887 /* MockRegisterUserUseCase.swift in Sources */,
+				EFF8B82A2CBFDCF4007470A9 /* MockLeaveEventUseCase.swift in Sources */,
 				EF2A6DDA2CAED73100164FD5 /* MockNavigationManager.swift in Sources */,
 				EFD6100E2CA2C44A00E3DB1E /* MockRemoteMyEventsDataSource.swift in Sources */,
 				EF31586E2C5A5DAF00DE157A /* MockLocalEventsDataSource.swift in Sources */,

--- a/EsmorgaiOS/App/API/Account/AccountNetworkService.swift
+++ b/EsmorgaiOS/App/API/Account/AccountNetworkService.swift
@@ -15,6 +15,7 @@ enum AccountNetworkService: NetworkService {
     case register(name: String, lastName: String, pass: String, email: String)
     case refresh(token: String)
     case join(eventId: String)
+    case leave(eventId: String)
 
     var url: URL { URL(string: "\(Bundle.baseURL)/v1")! }
 
@@ -23,13 +24,14 @@ enum AccountNetworkService: NetworkService {
         case .login: return "account/login"
         case .register: return "account/register"
         case .refresh: return "account/refresh"
-        case .myEvents, .join: return "account/events"
+        case .myEvents, .join, .leave: return "account/events"
         }
     }
 
     var method: HTTPMethod {
         switch self {
         case .myEvents: return .get
+        case .leave: return .delete
         default: return .post
         }
     }
@@ -53,7 +55,7 @@ enum AccountNetworkService: NetworkService {
             let json = ["refreshToken": token]
             return try? JSONSerialization.data(withJSONObject: json, options: [])
         case .myEvents: return nil
-        case .join(let eventId):
+        case .join(let eventId), .leave(let eventId):
             let json = ["eventId": eventId]
             return try? JSONSerialization.data(withJSONObject: json, options: [])
         }
@@ -61,7 +63,7 @@ enum AccountNetworkService: NetworkService {
 
     var requestInterceptor: RequestInterceptor? {
         switch self {
-        case .myEvents, .join:
+        case .myEvents, .join, .leave:
             return AuthenticationInterceptor(authenticator: AccountAuthenticator(),
                                              credential: AccountCredential())
         default: return nil

--- a/EsmorgaiOS/App/Data/DataSource/Events/RemoteMyEventsDataSource.swift
+++ b/EsmorgaiOS/App/Data/DataSource/Events/RemoteMyEventsDataSource.swift
@@ -8,6 +8,7 @@
 protocol RemoteMyEventsDataSourceProtocol {
     func fetchEvents() async throws -> [RemoteEventListModel.Event]
     func joinEvent(id: String) async throws
+    func leaveEvent(id: String) async throws
 }
 
 class RemoteMyEventsDataSource: RemoteMyEventsDataSourceProtocol {
@@ -30,6 +31,14 @@ class RemoteMyEventsDataSource: RemoteMyEventsDataSourceProtocol {
     func joinEvent(id: String) async throws {
         do {
             _  = try await networkRequest.request(networkService: AccountNetworkService.join(eventId: id)) as NetworkRequest.EmptyBodyObject
+        } catch let error {
+            throw error
+        }
+    }
+
+    func leaveEvent(id: String) async throws {
+        do {
+            _  = try await networkRequest.request(networkService: AccountNetworkService.leave(eventId: id)) as NetworkRequest.EmptyBodyObject
         } catch let error {
             throw error
         }

--- a/EsmorgaiOS/App/Data/Repository/EventsRepository.swift
+++ b/EsmorgaiOS/App/Data/Repository/EventsRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol EventsRepositoryProtocol {
     func getEventList(refresh: Bool) async throws -> ([EventModels.Event], Bool)
     func joinEvent(id: String) async throws
+    func leaveEvent(id: String) async throws
 }
 
 class EventsRepository: EventsRepositoryProtocol {
@@ -114,6 +115,15 @@ class EventsRepository: EventsRepositoryProtocol {
         do {
             try await remoteMyEventsDataSource.joinEvent(id: id)
             try await localEventsDataSource.updateIsUserJoinedEvent(id: id, isUserJoined: true)
+        } catch {
+            throw error
+        }
+    }
+
+    func leaveEvent(id: String) async throws {
+        do {
+            try await remoteMyEventsDataSource.leaveEvent(id: id)
+            try await localEventsDataSource.updateIsUserJoinedEvent(id: id, isUserJoined: false)
         } catch {
             throw error
         }

--- a/EsmorgaiOS/App/Data/UseCase/Event/LeaveEventUseCase.swift
+++ b/EsmorgaiOS/App/Data/UseCase/Event/LeaveEventUseCase.swift
@@ -12,15 +12,15 @@ typealias LeaveEventUseCaseAlias = BaseUseCase<String, JoinEventUseCaseResult>
 
 class LeaveEventUseCase: LeaveEventUseCaseAlias {
 
-    private var eventsRepsitory: EventsRepositoryProtocol
+    private var eventsRepository: EventsRepositoryProtocol
 
-    init(eventsRepsitory: EventsRepositoryProtocol = EventsRepository()) {
-        self.eventsRepsitory = eventsRepsitory
+    init(eventsRepository: EventsRepositoryProtocol = EventsRepository()) {
+        self.eventsRepository = eventsRepository
     }
 
     override func job(input: String) async -> LeaveEventUseCaseResult {
         do {
-            try await eventsRepsitory.leaveEvent(id: input)
+            try await eventsRepository.leaveEvent(id: input)
             return .success(())
         } catch {
             return .failure(error)

--- a/EsmorgaiOS/App/Data/UseCase/Event/LeaveEventUseCase.swift
+++ b/EsmorgaiOS/App/Data/UseCase/Event/LeaveEventUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  LeaveEventUseCase.swift
+//  EsmorgaiOS
+//
+//  Created by Vidal Pérez, Omar on 16/10/24.
+//
+
+import Foundation
+
+typealias LeaveEventUseCaseResult = Result<Void, Error>
+typealias LeaveEventUseCaseAlias = BaseUseCase<String, JoinEventUseCaseResult>
+
+class LeaveEventUseCase: LeaveEventUseCaseAlias {
+
+    private var eventsRepsitory: EventsRepositoryProtocol
+
+    init(eventsRepsitory: EventsRepositoryProtocol = EventsRepository()) {
+        self.eventsRepsitory = eventsRepsitory
+    }
+
+    override func job(input: String) async -> LeaveEventUseCaseResult {
+        do {
+            try await eventsRepsitory.leaveEvent(id: input)
+            return .success(())
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/EsmorgaiOS/App/Screens/EventList/EventListViewModel.swift
+++ b/EsmorgaiOS/App/Screens/EventList/EventListViewModel.swift
@@ -21,9 +21,8 @@ class EventListViewModel: BaseViewModel<EventListViewStates> {
                                                            title: LocalizationKeys.DefaultError.title.localize(),
                                                            subtitle: LocalizationKeys.DefaultError.body.localize(),
                                                            buttonText: LocalizationKeys.Buttons.retry.localize())
-
+    @Published var events: [EventModels.Event] = []
     private let getEventListUseCase: GetEventListUseCaseAlias
-    var events: [EventModels.Event] = []
 
     init(coordinator: (any CoordinatorProtocol)?,
          getEventListUseCase: GetEventListUseCaseAlias = GetEventListUseCase()) {

--- a/EsmorgaiOS/App/Screens/MyEvents/MyEventsViewModel.swift
+++ b/EsmorgaiOS/App/Screens/MyEvents/MyEventsViewModel.swift
@@ -28,7 +28,7 @@ class MyEventsViewModel: BaseViewModel<MyEventsViewStates> {
 
     private let getEventListUseCase: GetEventListUseCaseAlias
     private let getLocalUserUseCase: GetLocalUserUseCaseAlias
-    var events: [EventModels.Event] = []
+    @Published var events: [EventModels.Event] = []
 
     init(coordinator: (any CoordinatorProtocol)?,
          networkMonitor: NetworkMonitorProtocol = NetworkMonitor.shared,

--- a/EsmorgaiOSTests/App/Data/DataSource/Events/Mock/MockLocalEventsDataSource.swift
+++ b/EsmorgaiOSTests/App/Data/DataSource/Events/Mock/MockLocalEventsDataSource.swift
@@ -15,6 +15,7 @@ final class MockLocalEventsDataSource: LocalEventsDataSourceProtocol {
     var mockError: NSError = NSError(domain: "LocalEventsDataSource", code: 500, userInfo: [NSLocalizedDescriptionKey: "Failed to update event"])
     var updateEventIdCalled: String?
     var updateEventResult: Bool = false
+    var eventIsUserJoined: Bool?
     var clearAllCalled: Bool = false
 
     func getEvents() async -> [EventModels.Event] {
@@ -28,6 +29,7 @@ final class MockLocalEventsDataSource: LocalEventsDataSourceProtocol {
 
     func updateIsUserJoinedEvent(id: String, isUserJoined: Bool) async throws {
         updateEventIdCalled = id
+        eventIsUserJoined = isUserJoined
 
         guard updateEventResult else {
             throw mockError

--- a/EsmorgaiOSTests/App/Data/DataSource/Events/Mock/MockRemoteMyEventsDataSource.swift
+++ b/EsmorgaiOSTests/App/Data/DataSource/Events/Mock/MockRemoteMyEventsDataSource.swift
@@ -13,6 +13,7 @@ final class MockRemoteMyEventsDataSource: RemoteMyEventsDataSourceProtocol {
     var mockEvents: [RemoteEventListModel.Event]?
     var mockError: NetworkError = NetworkError.generalError(code: 500)
     var mockJoinedEvent: Bool = false
+    var mockLeaveEvent: Bool = false
     var eventIdJoined: String?
 
     func fetchEvents() async throws -> [RemoteEventListModel.Event] {
@@ -25,6 +26,13 @@ final class MockRemoteMyEventsDataSource: RemoteMyEventsDataSourceProtocol {
     func joinEvent(id: String) async throws {
         eventIdJoined = id
         guard mockJoinedEvent else {
+            throw mockError
+        }
+    }
+
+    func leaveEvent(id: String) async throws {
+        eventIdJoined = id
+        guard mockLeaveEvent else {
             throw mockError
         }
     }

--- a/EsmorgaiOSTests/App/Data/Repository/Events/EventsRepositoryTests.swift
+++ b/EsmorgaiOSTests/App/Data/Repository/Events/EventsRepositoryTests.swift
@@ -224,4 +224,48 @@ final class EventsRepositoryTests {
         #expect(self.mockRemoteMyEventsDataSource.eventIdJoined == id)
         #expect(self.mockLocalEventsDataSource.updateEventIdCalled == id)
     }
+
+    @Test
+    func test_given_leave_event_when_succes_then_store_the_event() async {
+        let id = "1234"
+        mockLocalEventsDataSource.updateEventResult = true
+        mockRemoteMyEventsDataSource.mockLeaveEvent = true
+
+        try? await sut.leaveEvent(id: id)
+
+        #expect(self.mockLocalEventsDataSource.updateEventIdCalled == id)
+        #expect(self.mockLocalEventsDataSource.eventIsUserJoined == false)
+        #expect(self.mockRemoteMyEventsDataSource.eventIdJoined == id)
+    }
+
+    @Test
+    func test_given_leave_event_when_join_event_fail_then_match_error() async {
+        let id = "1234"
+
+        do {
+            _ = try await sut.leaveEvent(id: id)
+            Issue.record("Expected error to be thrown")
+        } catch {
+            let expectedError = error as? NetworkError
+            #expect(expectedError == NetworkError.generalError(code: 500))
+        }
+
+        #expect(self.mockRemoteMyEventsDataSource.eventIdJoined == id)
+    }
+
+    @Test
+    func test_given_leave_event_when_store_event_fail_then_match_error() async {
+        let id = "1234"
+        mockRemoteMyEventsDataSource.mockLeaveEvent = true
+
+        do {
+            _ = try await sut.leaveEvent(id: id)
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect((error as NSError) == mockLocalEventsDataSource.mockError)
+        }
+
+        #expect(self.mockRemoteMyEventsDataSource.eventIdJoined == id)
+        #expect(self.mockLocalEventsDataSource.updateEventIdCalled == id)
+    }
 }

--- a/EsmorgaiOSTests/App/Data/Repository/Events/MockEventsRepository.swift
+++ b/EsmorgaiOSTests/App/Data/Repository/Events/MockEventsRepository.swift
@@ -14,6 +14,7 @@ final class MockEventsRepository: EventsRepositoryProtocol {
     var refreshValue: Bool?
 
     var joinEventResult: Bool = false
+    var leaveEventResult: Bool = false
     var eventIdToJoin: String?
 
     func getEventList(refresh: Bool) async throws -> ([EventModels.Event], Bool) {
@@ -27,6 +28,13 @@ final class MockEventsRepository: EventsRepositoryProtocol {
     func joinEvent(id: String) async throws {
         eventIdToJoin = id
         guard joinEventResult else {
+            throw NetworkError.generalError(code: 500)
+        }
+    }
+
+    func leaveEvent(id: String) async throws {
+        eventIdToJoin = id
+        guard leaveEventResult else {
             throw NetworkError.generalError(code: 500)
         }
     }

--- a/EsmorgaiOSTests/App/Data/UseCase/Events/LeaveEventUseCaseTests.swift
+++ b/EsmorgaiOSTests/App/Data/UseCase/Events/LeaveEventUseCaseTests.swift
@@ -17,7 +17,7 @@ final class LeaveEventUseCaseTests {
 
     init() {
         mockEventsRepository = MockEventsRepository()
-        sut = LeaveEventUseCase(eventsRepsitory: mockEventsRepository)
+        sut = LeaveEventUseCase(eventsRepository: mockEventsRepository)
     }
 
     deinit {

--- a/EsmorgaiOSTests/App/Data/UseCase/Events/LeaveEventUseCaseTests.swift
+++ b/EsmorgaiOSTests/App/Data/UseCase/Events/LeaveEventUseCaseTests.swift
@@ -1,8 +1,8 @@
 //
-//  JoinEventUseCaseTests.swift
+//  LeaveEventUseCaseTests.swift
 //  EsmorgaiOS
 //
-//  Created by Vidal Pérez, Omar on 15/10/24.
+//  Created by Vidal Pérez, Omar on 16/10/24.
 //
 
 import Foundation
@@ -10,14 +10,14 @@ import Testing
 @testable import EsmorgaiOS
 
 @Suite(.serialized)
-final class JoinEventUseCaseTests {
+final class LeaveEventUseCaseTests {
 
-    private var sut: JoinEventUseCase!
+    private var sut: LeaveEventUseCase!
     private var mockEventsRepository: MockEventsRepository!
 
     init() {
         mockEventsRepository = MockEventsRepository()
-        sut = JoinEventUseCase(eventsRepsitory: mockEventsRepository)
+        sut = LeaveEventUseCase(eventsRepsitory: mockEventsRepository)
     }
 
     deinit {
@@ -26,8 +26,8 @@ final class JoinEventUseCaseTests {
     }
 
     @Test
-    func test_given_join_event_when_success_result_then_return_correct_events() async {
-        mockEventsRepository.joinEventResult = true
+    func test_given_leave_event_when_success_result_then_return_correct_events() async {
+        mockEventsRepository.leaveEventResult = true
 
         let result = await self.sut.execute(input: "123")
         var successCalled: Bool?
@@ -42,7 +42,7 @@ final class JoinEventUseCaseTests {
     }
 
     @Test
-    func test_given_join_event_when_failure_result_then_return_correct_error() async {
+    func test_given_leave_event_when_failure_result_then_return_correct_error() async {
 
         let result = await self.sut.execute(input: "1234")
         switch result {

--- a/EsmorgaiOSTests/App/Data/UseCase/Events/Mocks/MockLeaveEventUseCase.swift
+++ b/EsmorgaiOSTests/App/Data/UseCase/Events/Mocks/MockLeaveEventUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  MockLeaveEventUseCase.swift
+//  EsmorgaiOS
+//
+//  Created by Vidal Pérez, Omar on 16/10/24.
+//
+
+import Foundation
+@testable import EsmorgaiOS
+
+final class MockLeaveEventUseCase: LeaveEventUseCaseAlias {
+
+    var mockResult: Bool = false
+
+    override func job(input: String) async -> LeaveEventUseCaseResult {
+        guard mockResult else {
+            return .failure(NetworkError.generalError(code: 500))
+        }
+        return .success(())
+    }
+}


### PR DESCRIPTION
MOB-68 Leave Event.
Create leaveEvent network service.
Create LeaveEventUseCase.
Add method in RemoteMyEventsDataSource and EventsRepository to leave event.
Add logic to leave event in MyEventsViewModel when primary button is tapped.
Added TCs